### PR TITLE
lib: fix code highlighting for intellisense

### DIFF
--- a/include/msx-types.h
+++ b/include/msx-types.h
@@ -19,6 +19,8 @@ typedef u8 bool;
 
 #if !defined(__INTELLISENSE__)
 #define SDCCCALL(value) __sdcccall(value)
+#else
+#define SDCCCALL(value)
 #endif
 
 #define UNUSED(value) (value)


### PR DESCRIPTION
Intellisense 上で SDCCCALL() マクロがエラー表示になってしまうので修正しました。