### PR TITLE
ugcube: suppress warnings

### DIFF
--- a/projects/ug2/ugcube/clip.h
+++ b/projects/ug2/ugcube/clip.h
@@ -37,13 +37,13 @@ extern SLine16 g_clipLineInOut;
 
 #define Clip_VDPWaitLine() VDPWaitLine(g_clipLineInOut.sx, g_clipLineInOut.sy, g_clipLineInOut.ex, g_clipLineInOut.ey)
 
-s8 ClipLeft() SDCCCALL(0);
-s8 ClipRight() SDCCCALL(0);
-s8 ClipTop() SDCCCALL(0);
-s8 ClipBottom() SDCCCALL(0);
-s8 ClipRect() SDCCCALL(0);
+extern s8 ClipLeft(void) SDCCCALL(0);
+extern s8 ClipRight(void) SDCCCALL(0);
+extern s8 ClipTop(void) SDCCCALL(0);
+extern s8 ClipBottom(void) SDCCCALL(0);
+extern s8 ClipRect(void) SDCCCALL(0);
 
-void ClipRect_VDPWaitLine() SDCCCALL(0);
+extern void ClipRect_VDPWaitLine(void) SDCCCALL(0);
 
 typedef struct 
 {
@@ -53,7 +53,7 @@ typedef struct
 
 extern SLine8x3 g_clipLineS8x3;
 
-s8 ClipLineS8x3(s8 s8Near) SDCCCALL(0);
+extern s8 ClipLineS8x3(s8 s8Near) SDCCCALL(0);
 
 
 #endif //CLIP_H

--- a/projects/ug2/ugcube/flipper.c
+++ b/projects/ug2/ugcube/flipper.c
@@ -45,7 +45,7 @@ void FlipperInit
     VDPPaletteWrite(s_pConfig->m_clearValue & 0x0f, &g_flipper.m_u16Background0GRB, 1);
 }
 
-void FlipperTerm()
+void FlipperTerm(void)
 {
     msx2BiosChangeModePalette(5);
     VDPSetActivePage(0);
@@ -65,19 +65,19 @@ void FlipperPrint(u16 x, u16 y, u8 color, const char *pszText)
     VDPSetActivePage(g_flipper.m_u8ActivePage);
 }
 
-void FlipperClear()
+void FlipperClear(void)
 {
     const SFlipperTile *pTile = g_flipper.m_pTile;
     VDPSetForegroundColor(s_pConfig->m_clearValue);
 	VDPFill(pTile->x, pTile->y, pTile->w, pTile->h);
 }
 
-void FlipperApplyForegroundColor()
+void FlipperApplyForegroundColor(void)
 {
     VDPSetForegroundColor(g_flipper.m_u8Tile);
 }
 
-void FlipperFlip()
+void FlipperFlip(void)
 {
     if (!g_flipper.m_u8ActivePage)
     {

--- a/projects/ug2/ugcube/flipper.h
+++ b/projects/ug2/ugcube/flipper.h
@@ -32,7 +32,7 @@ typedef struct tFlipper
     u8 m_u8DisplayPage;
     u8 m_u8ActivePage;
     u8 m_u8Tile;
-    SFlipperTile *m_pTile;
+    const SFlipperTile *m_pTile;
 
     u16 m_u16Background0GRB;    //< background palette.
     u16 m_u16Foreground0GRB;    //< foreground palette.
@@ -48,19 +48,19 @@ extern void FlipperInit
     u16 u16Foreground0GRB           //< foreground palette.
 );
 
-extern void FlipperTerm();
+extern void FlipperTerm(void);
 
 extern void FlipperSetForegroundColor(u16 u160GRB);
 
 extern void FlipperPrint(u16 x, u16 y, u8 color, const char *pszText);
 
 //! clear screen.
-extern void FlipperClear();
+extern void FlipperClear(void);
 
 //! apply current foreground color code to FORCLR
-extern void FlipperApplyForegroundColor();
+extern void FlipperApplyForegroundColor(void);
 
 //! flip page and palettes.
-extern void FlipperFlip();
+extern void FlipperFlip(void);
 
 #endif //FLIPPER_H

--- a/projects/ug2/ugcube/halt.h
+++ b/projects/ug2/ugcube/halt.h
@@ -2,6 +2,6 @@
 #define HALT_H
 #include <msx-types.h>
 
-extern void Halt() SDCCCALL(0);
+extern void Halt(void) SDCCCALL(0);
 
 #endif //HALT_H

--- a/projects/ug2/ugcube/main.c
+++ b/projects/ug2/ugcube/main.c
@@ -9,7 +9,7 @@
 #pragma codeseg CODE2
 
 u8 g_u8Timer = 0;
-void OnTimer()
+void OnTimer(void)
 {
 	g_u8Timer++;
 }

--- a/projects/ug2/ugcube/mtk_effect.c
+++ b/projects/ug2/ugcube/mtk_effect.c
@@ -5,7 +5,7 @@
 
 SMtkEffect g_mtkEfects[MTK_EFFECT_MAX];
 
-void MtkEffectInit()
+void MtkEffectInit(void)
 {
 	u8 i;
 	SMtkEffect *pEffect = g_mtkEfects;
@@ -39,7 +39,7 @@ u8 MtkEffectSpawn(enum EMtkEffectType type, const s16x3 *pPosition, const s16x3 
 	return FALSE;
 }
 
-void MtkEffectUpdate()
+void MtkEffectUpdate(void)
 {
 	u8 i;
 	SMtkEffect *pEffect = g_mtkEfects;

--- a/projects/ug2/ugcube/mtk_effect.h
+++ b/projects/ug2/ugcube/mtk_effect.h
@@ -19,8 +19,8 @@ enum EMtkEffectType
 
 #define MTK_EFFECT_MAX (3)
 extern SMtkEffect g_mtkEfects[MTK_EFFECT_MAX];
-extern void MtkEffectInit();
+extern void MtkEffectInit(void);
 extern u8 MtkEffectSpawn(enum EMtkEffectType type, const s16x3 *pPosition, const s16x3 *pVelocity);
-extern void MtkEffectUpdate();
+extern void MtkEffectUpdate(void);
 
 #endif //MTK_EFFECT_H

--- a/projects/ug2/ugcube/mtk_enemy.c
+++ b/projects/ug2/ugcube/mtk_enemy.c
@@ -5,7 +5,7 @@
 #pragma codeseg CODE2
 
 SMtkEnemy g_mtkEnemies[MTK_ENEMY_MAX];
-void MtkEnemyInit()
+void MtkEnemyInit(void)
 {
 	u8 i;
 	SMtkEnemy *pEnemy = g_mtkEnemies;
@@ -22,7 +22,7 @@ void MtkEnemyInit()
 	}
 }
 
-void MtkEnemyUpdate()
+void MtkEnemyUpdate(void)
 {
 	u8 i;
 	SMtkEnemy *pEnemy;

--- a/projects/ug2/ugcube/mtk_enemy.h
+++ b/projects/ug2/ugcube/mtk_enemy.h
@@ -20,7 +20,7 @@ enum EMtkEnemyStatus
 #define MTK_ENEMY_MAX (3)
 extern SMtkEnemy g_mtkEnemies[MTK_ENEMY_MAX];
 
-extern void MtkEnemyInit();
-extern void MtkEnemyUpdate();
+extern void MtkEnemyInit(void);
+extern void MtkEnemyUpdate(void);
 
 #endif //MTK_ENEMY_H

--- a/projects/ug2/ugcube/mtk_input.c
+++ b/projects/ug2/ugcube/mtk_input.c
@@ -4,7 +4,7 @@
 #pragma codeseg CODE2
 
 SMtkInput g_mtkInput;
-void MtkInputInit()
+void MtkInputInit(void)
 {
 	g_mtkInput.m_down = 0;
 	g_mtkInput.m_up = 0xff;
@@ -12,7 +12,7 @@ void MtkInputInit()
 	g_mtkInput.m_release = 0;
 }
 
-void MtkInputScan()
+void MtkInputScan(void)
 {
 	u8 down = 0;
 	u8 i;

--- a/projects/ug2/ugcube/mtk_input.h
+++ b/projects/ug2/ugcube/mtk_input.h
@@ -22,8 +22,8 @@ enum EMtkInput
 };
 
 extern SMtkInput g_mtkInput;
-extern void MtkInputInit();
-extern void MtkInputScan();
+extern void MtkInputInit(void);
+extern void MtkInputScan(void);
 
 #define MtkInputIsDown(input)    (g_mtkInput.m_down    & (input))
 #define MtkInputIsUp(input)      (g_mtkInput.m_up      & (input))

--- a/projects/ug2/ugcube/mtk_main.c
+++ b/projects/ug2/ugcube/mtk_main.c
@@ -30,7 +30,7 @@ static u16 s_vertices[64];
 
 extern u8 g_u8Timer;
 
-void WaitVSync()
+void WaitVSync(void)
 {
 	volatile u8 u8Timer = g_u8Timer;
 	while(u8Timer == g_u8Timer);
@@ -87,7 +87,7 @@ const s16 kMtk_ViewportBottom = 16 + 96 + 96 - 1;
 s8x3 g_mtkStars[MTK_STAR_MAX];
 s8x3 g_mtkStarPosition;
 
-void MtkStarInit()
+void MtkStarInit(void)
 {
 	u8 i;
 	s8x3 *pStar = g_mtkStars;
@@ -104,14 +104,14 @@ void MtkStarInit()
 	s8x3Set(g_mtkStarPosition, 0, 0, 0);
 }
 
-void MtkStarUpdate()
+void MtkStarUpdate(void)
 {
 	s8x3Op(g_mtkStarPosition, g_mtkStarPosition, -, g_mtkPlayer.m_velocity);
 }
 
-extern void MtkStarRender();
+extern void MtkStarRender(void);
 
-void MtkInit()
+void MtkInit(void)
 {
 	msxRandInit(0x53, 0x94a1);
 

--- a/projects/ug2/ugcube/mtk_player.c
+++ b/projects/ug2/ugcube/mtk_player.c
@@ -4,12 +4,12 @@
 #pragma codeseg CODE2
 
 SMtkPlayer g_mtkPlayer;
-void MtkPlayerInit()
+void MtkPlayerInit(void)
 {
 	s16x3Set(g_mtkPlayer.m_velocity,0,0,0);
 }
 
-void MtkPlayerUpdate()
+void MtkPlayerUpdate(void)
 {
 	s16 vx = g_mtkPlayer.m_velocity.x;
 	s16 vy = g_mtkPlayer.m_velocity.y;

--- a/projects/ug2/ugcube/mtk_player.h
+++ b/projects/ug2/ugcube/mtk_player.h
@@ -9,7 +9,7 @@ typedef struct tMtkPlayer
 } SMtkPlayer;
 extern SMtkPlayer g_mtkPlayer;
 
-extern void MtkPlayerInit();
-extern void MtkPlayerUpdate();
+extern void MtkPlayerInit(void);
+extern void MtkPlayerUpdate(void);
 
 #endif //MTK_PLAYER_H

--- a/projects/ug2/ugcube/mtk_shot.c
+++ b/projects/ug2/ugcube/mtk_shot.c
@@ -6,7 +6,7 @@
 
 SMtkShot g_mtkShots[MTK_SHOT_MAX];
 
-void MtkShotInit()
+void MtkShotInit(void)
 {
 	u8 i;
 	SMtkShot *pShot = g_mtkShots;
@@ -19,7 +19,7 @@ void MtkShotInit()
 	}
 }
 
-void MtkShotUpdate()
+void MtkShotUpdate(void)
 {
 	u8 i;
 	SMtkShot *pShot = g_mtkShots;

--- a/projects/ug2/ugcube/mtk_shot.h
+++ b/projects/ug2/ugcube/mtk_shot.h
@@ -20,7 +20,7 @@ enum EMtkShotStatus
 #define MTK_SHOT_MAX (4)
 extern SMtkShot g_mtkShots[MTK_SHOT_MAX];
 
-extern void MtkShotInit();
-extern void MtkShotUpdate();
+extern void MtkShotInit(void);
+extern void MtkShotUpdate(void);
 
 #endif //MTK_SHOT_H

--- a/projects/ug2/ugcube/pers.c
+++ b/projects/ug2/ugcube/pers.c
@@ -24,8 +24,8 @@ SDCC_FIXED_ADDRESS(PersTransform_RcpZ)     u16  s_u16TransformRcpZ[128];
 //. transform positions.
 SDCC_FIXED_ADDRESS(PersTransform_Positions)  u8  s_u8TransformPositions[];
 
-static void PersMakeTransformTable();
-static void PersMakeTransformRcpZTable();
+static void PersMakeTransformTable(void);
+static void PersMakeTransformRcpZTable(void);
 
 void PersInit
 (
@@ -58,7 +58,7 @@ void PersInit
     PersMakeTransformRcpZTable();
 }
 
-static void PersMakeTransformRcpZTable()
+static void PersMakeTransformRcpZTable(void)
 {
     u8 z;
     u16 u16ScreenZ = ((u16)g_persContext.m_s16ScreenZ) << 8;
@@ -77,7 +77,7 @@ static void PersMakeTransformRcpZTable()
     }
 }
 
-void PersMakeTransformTable()
+void PersMakeTransformTable(void)
 {
     const s8 s8ClipNear = g_persContext.m_s8ClipNear;
     const s16 s16ScreenX = g_persContext.m_s16ScreenX;
@@ -341,7 +341,7 @@ void PersSetViewport(s16 left, s16 top, s16 right, s16 bottom)
     Clip_SetRect(left,right,top,bottom);
 }
 
-const SPersScreenPos* PersGetPostions()
+const SPersScreenPos* PersGetPostions(void)
 {
     return s_screenPositions;
 }

--- a/projects/ug2/ugcube/pers.h
+++ b/projects/ug2/ugcube/pers.h
@@ -96,7 +96,7 @@ extern u8 PersClipBBox(const SBBox *pBBox, s8 x, s8 y, s8 z, s8 near) SDCCCALL(0
 extern u16 PersCreateBBox(u16 vramOffset, u8 nbVertices) SDCCCALL(0);
 extern u8 PersClipBBoxVram(u16 vramOffset, s8 x, s8 y, s8 z, s8 near) SDCCCALL(0);
 
-extern const SPersScreenPos* PersGetPostions();
+extern const SPersScreenPos* PersGetPostions(void);
 
 #define PersTransform_Pointers     (0xC000) //. 2*128 entries.
 #define PersTransform_Left         (0xC100) //. 1*128 entries.

--- a/projects/ug2/ugcube/test.c
+++ b/projects/ug2/ugcube/test.c
@@ -16,7 +16,7 @@ void Test_DrawTitle(const char *pszTitle)
 	VDPPrint(0,0,pszTitle);
 }
 
-void Test_DrawTimerAndWait()
+void Test_DrawTimerAndWait(void)
 {
 	volatile u8 u8Timer = g_u8Timer;
 	VDPSetForegroundColor(0xff);

--- a/projects/ug2/ugcube/test.h
+++ b/projects/ug2/ugcube/test.h
@@ -17,7 +17,7 @@ extern void Test_BBoxClip(const char* pszTitle);
 
 //. test.c
 extern void Test_DrawTitle(const char *pszTitle);
-extern void Test_DrawTimerAndWait();
+extern void Test_DrawTimerAndWait(void);
 extern void Test_WaitForTrigger(const char *pszTitle);
 extern void Test(const char *pszTitle);
 

--- a/projects/ug2/ugcube/vdp_command.h
+++ b/projects/ug2/ugcube/vdp_command.h
@@ -46,7 +46,7 @@ extern void VDPSetDisplayPage(u8 nPage);
 #define VDPSetBorderColor(_color) BDRCLR=_color
 #define VDPSetColor(_fg,_bg,_bd) FORCLR=_fg;BAKCLR=_bg;BDRCLR=_bd
 
-void VDPWait() SDCCCALL(0);
+void VDPWait(void) SDCCCALL(0);
 void VDPWaitLine(u8 sx, u8 sy, u8 ex, u8 ey) SDCCCALL(0);
 void VDPWaitLine2(u8 sx, u8 sy, u8 ex, u8 ey) SDCCCALL(0);
 


### PR DESCRIPTION
引数がない場合に void を明示しないと Warning となってしまうため修正しました。